### PR TITLE
Feat: Adjust Satflow Pricing Logic

### DIFF
--- a/src/services/core/environment.js
+++ b/src/services/core/environment.js
@@ -7,6 +7,9 @@ const SATFLOW_API_BASE_URL = 'https://api.satflow.com/v1';
 // Magic Eden maker fee multiplier (0.5% fee)
 const MAGIC_EDEN_FEE_MULTIPLIER = 1.005;
 
+// Magic Eden taker fee multiplier (2%)
+const MAGIC_EDEN_TAKER_FEE_MULTIPLIER = 1.02;
+
 // Global flag to track if below-floor confirmation has been given
 let belowFloorConfirmationGiven = false;
 
@@ -279,6 +282,7 @@ function validateBaseEnvironment() {
 module.exports = {
   SATFLOW_API_BASE_URL,
   MAGIC_EDEN_FEE_MULTIPLIER,
+  MAGIC_EDEN_TAKER_FEE_MULTIPLIER,
   validateBaseEnvironment,
   validateWalletEnvironment,
   parseBidLadder,

--- a/src/services/protocols/ordinals/collection-manager.js
+++ b/src/services/protocols/ordinals/collection-manager.js
@@ -1,7 +1,7 @@
 const { BaseCollectionManager } = require('../../core/collection-manager');
 const { OrdinalsBiddingService } = require('./bidding');
 const { fetchMarketPrice, fetchMyListings, fetchCollectionBids } = require('./market');
-const { calculateTargetPrice, calculateDynamicPrice, calculateDynamicBidPrice } = require('./pricing');
+const { calculateTargetPrice, calculateDynamicPrice, calculateDynamicBidPrice, calculateSatflowDynamicPrice } = require('./pricing');
 const { listOnSatflow, listOnMagicEden } = require('../../listings');
 const { parseBidLadder, MAGIC_EDEN_FEE_MULTIPLIER } = require('../../core/environment');
 const { logError } = require('../../../utils/logger');
@@ -405,7 +405,7 @@ class OrdinalsCollectionManager extends BaseCollectionManager {
 
         // --- PLATFORM-SPECIFIC PRICING ---
         // Calculate Satflow Price
-        let finalSatflowPrice = calculateDynamicPrice(targetListPrice, satflowListings);
+        let finalSatflowPrice = calculateSatflowDynamicPrice(targetListPrice, meListings, satflowListings);
 
         // Calculate Magic Eden Price
         const baseMagicEdenPrice = calculateDynamicPrice(targetListPrice, meListings);
@@ -414,13 +414,6 @@ class OrdinalsCollectionManager extends BaseCollectionManager {
         // Apply ME fee multiplier ONLY if no undercutting occurred
         if (baseMagicEdenPrice === targetListPrice) {
           finalMagicEdenPrice = Math.ceil(baseMagicEdenPrice * MAGIC_EDEN_FEE_MULTIPLIER);
-        }
-
-        // --- CROSS-MARKET ADJUSTMENT ---
-        // If the final ME price is lower than the final Satflow price, match it.
-        if (finalMagicEdenPrice < finalSatflowPrice) {
-            console.log(`ℹ Matching ME's aggressive price on Satflow: ${finalMagicEdenPrice} sats (was ${finalSatflowPrice})`);
-            finalSatflowPrice = finalMagicEdenPrice;
         }
 
         // Get all existing listings for this inscription


### PR DESCRIPTION
This PR adjusts the Satflow opportunistic pricing to correctly account for the 2% Magic Eden taker fee. A new, specific pricing function has been created for Satflow, and the logic now uses the true floor price (including ME fees) for more accurate undercutting. The variable naming for the fee multiplier has also been clarified.