### PR TITLE
refactor(pricing): Ignore UPDATE_THRESHOLD for undercuts

### DIFF
--- a/src/services/core/environment.js
+++ b/src/services/core/environment.js
@@ -7,6 +7,9 @@ const SATFLOW_API_BASE_URL = 'https://api.satflow.com/v1';
 // Magic Eden maker fee multiplier (0.5% fee)
 const MAGIC_EDEN_FEE_MULTIPLIER = 1.005;
 
+// Magic Eden taker fee multiplier (2%)
+const MAGIC_EDEN_TAKER_FEE_MULTIPLIER = 1.02;
+
 // Global flag to track if below-floor confirmation has been given
 let belowFloorConfirmationGiven = false;
 
@@ -279,6 +282,7 @@ function validateBaseEnvironment() {
 module.exports = {
   SATFLOW_API_BASE_URL,
   MAGIC_EDEN_FEE_MULTIPLIER,
+  MAGIC_EDEN_TAKER_FEE_MULTIPLIER,
   validateBaseEnvironment,
   validateWalletEnvironment,
   parseBidLadder,

--- a/src/services/protocols/ordinals/collection-manager.js
+++ b/src/services/protocols/ordinals/collection-manager.js
@@ -1,7 +1,7 @@
 const { BaseCollectionManager } = require('../../core/collection-manager');
 const { OrdinalsBiddingService } = require('./bidding');
 const { fetchMarketPrice, fetchMyListings, fetchCollectionBids } = require('./market');
-const { calculateTargetPrice, calculateDynamicPrice, calculateDynamicBidPrice } = require('./pricing');
+const { calculateTargetPrice, calculateDynamicPrice, calculateDynamicBidPrice, calculateSatflowDynamicPrice } = require('./pricing');
 const { listOnSatflow, listOnMagicEden } = require('../../listings');
 const { parseBidLadder, MAGIC_EDEN_FEE_MULTIPLIER } = require('../../core/environment');
 const { logError } = require('../../../utils/logger');
@@ -405,7 +405,7 @@ class OrdinalsCollectionManager extends BaseCollectionManager {
 
         // --- PLATFORM-SPECIFIC PRICING ---
         // Calculate Satflow Price
-        let finalSatflowPrice = calculateDynamicPrice(targetListPrice, satflowListings);
+        let finalSatflowPrice = calculateSatflowDynamicPrice(targetListPrice, meListings, satflowListings);
 
         // Calculate Magic Eden Price
         const baseMagicEdenPrice = calculateDynamicPrice(targetListPrice, meListings);
@@ -414,13 +414,6 @@ class OrdinalsCollectionManager extends BaseCollectionManager {
         // Apply ME fee multiplier ONLY if no undercutting occurred
         if (baseMagicEdenPrice === targetListPrice) {
           finalMagicEdenPrice = Math.ceil(baseMagicEdenPrice * MAGIC_EDEN_FEE_MULTIPLIER);
-        }
-
-        // --- CROSS-MARKET ADJUSTMENT ---
-        // If the final ME price is lower than the final Satflow price, match it.
-        if (finalMagicEdenPrice < finalSatflowPrice) {
-            console.log(`ℹ Matching ME's aggressive price on Satflow: ${finalMagicEdenPrice} sats (was ${finalSatflowPrice})`);
-            finalSatflowPrice = finalMagicEdenPrice;
         }
 
         // Get all existing listings for this inscription

--- a/src/services/protocols/ordinals/pricing.js
+++ b/src/services/protocols/ordinals/pricing.js
@@ -11,23 +11,25 @@ function calculateTargetPrice(listings, collectionSymbol) {
 
 function calculateDynamicPrice(targetPrice, marketListings) {
     if (!marketListings || marketListings.length === 0) {
-        return targetPrice;
+        return { price: targetPrice, isUndercut: false };
     }
 
     const floorPrice = marketListings[0].price;
+    let isUndercut = false;
 
     // Opportunistic Undercutting: If target is within 1% of floor, undercut by 1000 sats
     if (targetPrice >= floorPrice && targetPrice <= floorPrice * 1.01) {
-        return floorPrice - 1000;
+        isUndercut = true;
+        return { price: floorPrice - 1000, isUndercut };
     }
 
     // Just Below Floor: If target is already below floor, standardize to 1000 sats below
     if (targetPrice < floorPrice) {
-        return floorPrice - 1000;
+        return { price: floorPrice - 1000, isUndercut };
     }
 
     // Default: Return original target price
-    return targetPrice;
+    return { price: targetPrice, isUndercut };
 }
 
 function calculateDynamicBidPrice(targetBidPrice, marketBids) {
@@ -55,23 +57,25 @@ function calculateSatflowDynamicPrice(targetPrice, meListings, satflowListings) 
     const meFloor = meListings.length > 0 ? meListings[0].price * MAGIC_EDEN_TAKER_FEE_MULTIPLIER : Infinity;
     const satflowFloor = satflowListings.length > 0 ? satflowListings[0].price : Infinity;
     const trueFloor = Math.min(meFloor, satflowFloor);
+    let isUndercut = false;
 
     if (!isFinite(trueFloor)) {
-        return targetPrice;
+        return { price: targetPrice, isUndercut };
     }
 
     // Opportunistic Undercutting: If target is within 1% of the true floor, undercut by 1000 sats
     if (targetPrice >= trueFloor && targetPrice <= trueFloor * 1.01) {
-        return trueFloor - 1000;
+        isUndercut = true;
+        return { price: trueFloor - 1000, isUndercut };
     }
 
     // Just Below Floor: If target is already below floor, standardize to 1000 sats below
     if (targetPrice < trueFloor) {
-        return trueFloor - 1000;
+        return { price: trueFloor - 1000, isUndercut };
     }
 
     // Default: Return original target price
-    return targetPrice;
+    return { price: targetPrice, isUndercut };
 }
 
 module.exports = {


### PR DESCRIPTION
Refactors the pricing logic to allow opportunistic undercutting at the floor price to ignore the UPDATE_THRESHOLD.

- The `calculateDynamicPrice` and `calculateSatflowDynamicPrice` functions now return an object with a `price` and an `isUndercut` boolean flag.
- The `OrdinalsCollectionManager` now uses this flag to bypass the update threshold check only when an undercut occurs.
- This prevents duplicated logic and ensures aggressive floor undercutting while respecting the threshold for other price adjustments.