### PR TITLE
Make Magic Eden optional with Satflow-first market data

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -35,7 +35,12 @@ LOCAL_WALLET_SEED_ENCRYPTED="your-encrypted-seed-here"
 SATFLOW_API_KEY="your-satflow-api-key"
 
 # Optional Configuration
-#ZENROWS_API_KEY="your-zenrows-api-key"
+# Set to true to enable Magic Eden integrations (market indexing + external listing)
+# Default is false (Satflow-only mode).
+ENABLE_MAGIC_EDEN=false
+
+# Optional: only used when ENABLE_MAGIC_EDEN=true for Ordinals bid-feed indexing
+# ZENROWS_API_KEY="your-zenrows-api-key"
 
 # Comma-separated list of additional wallet addresses to ignore when fetching market listings
 # These addresses' listings will be excluded from price calculations (in addition to your own wallet's listings)
@@ -89,7 +94,7 @@ NODEMONKES_BID_BELOW_PERCENT=0.8
 # Format: [RUNE_TICKER]_LIST_ABOVE_PERCENT=[value]
 # Format: [RUNE_TICKER]_MAX_BID_TOTAL=[amount]
 # Format: [RUNE_TICKER]_MARKET_DEPTH_SATS=[amount] (required, e.g. 10000000 for 10M sats depth)
-# Format: [RUNE_TICKER]_FULL_TICKER=[value] (required, maps shortened ticker to full ticker with dots)
+# Format: [RUNE_TICKER]_FULL_TICKER=[value] (required, maps shortened ticker to full ticker with dots for Satflow API mapping)
 
 # DOGGOTOTHEMOON Rune Settings
 DOGGOTOTHEMOON_LIST_ABOVE_PERCENT=1.2

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This Node.js application automates bidding and listing for Ordinals/Rune marketplace items. It currently uses:
 
-- Magic Eden (as a price index source)
-- Satflow (for listing items and, later, placing bids)
+- Satflow (for wallet data, market data, listing items, and placing bids)
+- Magic Eden (optional, only when explicitly enabled)
 
 The application supports both Ordinals collections and Runes:
 - Ordinals collections (e.g., Runestone, NodeMonkes)
@@ -32,7 +32,8 @@ The application supports both Ordinals collections and Runes:
 | `LOOP_SECONDS` | Interval (in seconds) for each run | 15 |
 | `UPDATE_THRESHOLD` | Minimum price difference (as decimal) required before updating listings/bids | 0.01 (1%) |
 | `IGNORED_MARKET_ADDRESSES` | Comma-separated list of wallet addresses whose listings should be excluded from price calculations | - |
-| `ZENROWS_API_KEY` | API key for ZenRows (used to proxy or scrape data from Magic Eden) | - |
+| `ENABLE_MAGIC_EDEN` | Enables optional Magic Eden integrations (`true`/`false`) | `false` |
+| `ZENROWS_API_KEY` | API key for ZenRows (only used when `ENABLE_MAGIC_EDEN=true` to fetch Ordinals bid feed) | - |
 
 ### Collection-Specific Variables
 
@@ -58,6 +59,7 @@ For Runes (e.g., DOGGOTOTHEMOON), the following variables can be set:
 | `{RUNE_TICKER}_BID_BELOW_PERCENT` | Multiplier to bid below the average price (e.g., 0.8 = 80% of average) | 0.8 |
 | `{RUNE_TICKER}_BID_LADDER` | Alternative to BID_BELOW_PERCENT: Defines multiple price points with allocations (e.g., "0.9:0.2,0.85:0.3,0.8:0.5") | - |
 | `{RUNE_TICKER}_MAX_BID_TOTAL` | Maximum total amount in sats to bid on this rune | Infinity |
+| `{RUNE_TICKER}_FULL_TICKER` | **Required**: Full rune name with separators for Satflow mapping (e.g., `DOG•GO•TO•THE•MOON`) | - |
 
 ### Premium Inscription Pricing
 
@@ -109,7 +111,8 @@ For enhanced security, especially in production environments, you can encrypt yo
    ```
 
 5. **Signing into Marketplaces**:
-   - Ensure that your wallet address in `.env` matches the address you use on Satflow and Magic Eden
+   - Ensure that your wallet address in `.env` matches the address you use on Satflow
+   - If `ENABLE_MAGIC_EDEN=true`, this address should also match your Magic Eden wallet
    - This address should hold the Ordinal inscriptions and Runes you intend to list
 
 ## How It Works
@@ -117,8 +120,9 @@ For enhanced security, especially in production environments, you can encrypt yo
 1. **Collection/Rune Configuration**: The bot processes multiple collections and runes specified in the `COLLECTIONS` environment variable.
 
 2. **Fetch Price Data**: 
-   - For Ordinals collections: Calls Magic Eden to get listed items and their sat prices
-   - For Runes: Calls Magic Eden's runes API to get order book data
+   - For Ordinals collections: Calls Satflow to get listed items and their sat prices
+   - For Runes: Calls Satflow listings to build rune order data by depth
+   - If `ENABLE_MAGIC_EDEN=true`, Magic Eden feeds are used as optional secondary inputs/fallbacks
 
 3. **Calculate Average**: 
    - For Ordinals: Gathers the cheapest N items (default: 10, configurable via `{COLLECTION}_NUM_CHEAPEST_ITEMS`) to compute a baseline average price

--- a/src/services/core/environment.js
+++ b/src/services/core/environment.js
@@ -170,7 +170,8 @@ function validateBaseEnvironment() {
   const baseRequired = [
     'COLLECTIONS',
     'UPDATE_THRESHOLD',
-    'MAX_BID_TO_LIST_RATIO'
+    'MAX_BID_TO_LIST_RATIO',
+    'SATFLOW_API_KEY'
   ];
   
   const missing = baseRequired.filter(key => !process.env[key]);
@@ -276,6 +277,10 @@ function validateBaseEnvironment() {
   }
 }
 
+function isMagicEdenEnabled() {
+  return String(process.env.ENABLE_MAGIC_EDEN || '').toLowerCase() === 'true';
+}
+
 module.exports = {
   SATFLOW_API_BASE_URL,
   MAGIC_EDEN_FEE_MULTIPLIER,
@@ -283,5 +288,6 @@ module.exports = {
   validateWalletEnvironment,
   parseBidLadder,
   parsePremiumRanges,
-  checkBelowFloorListings
+  checkBelowFloorListings,
+  isMagicEdenEnabled
 };

--- a/src/services/protocols/ordinals/collection-manager.js
+++ b/src/services/protocols/ordinals/collection-manager.js
@@ -3,7 +3,7 @@ const { OrdinalsBiddingService } = require('./bidding');
 const { fetchMarketPrice, fetchMyListings, fetchCollectionBids } = require('./market');
 const { calculateTargetPrice, calculateDynamicPrice, calculateDynamicBidPrice } = require('./pricing');
 const { listOnSatflow, listOnMagicEden } = require('../../listings');
-const { parseBidLadder, MAGIC_EDEN_FEE_MULTIPLIER } = require('../../core/environment');
+const { parseBidLadder, MAGIC_EDEN_FEE_MULTIPLIER, isMagicEdenEnabled } = require('../../core/environment');
 const { logError } = require('../../../utils/logger');
 const { deriveWalletDetails } = require('../../wallet-utils');
 
@@ -40,6 +40,10 @@ class OrdinalsCollectionManager extends BaseCollectionManager {
   async processCollection(collectionId, walletItems, biddingAddress, biddingBalance) {
     console.log(`\n=== Processing ${collectionId} ===`);
     console.log(`Using bidding wallet: ${biddingAddress} (${biddingBalance} sats)`);
+    const useMagicEden = isMagicEdenEnabled();
+    if (!useMagicEden) {
+      console.log('Magic Eden integrations are disabled for this run');
+    }
 
     // Get existing bids for this collection
     let existingBids = [];
@@ -64,7 +68,7 @@ class OrdinalsCollectionManager extends BaseCollectionManager {
     }
 
     // Fetch market data and calculate prices
-    const { meListings, satflowListings } = await fetchMarketPrice(collectionId);
+    const { meListings, satflowListings } = await fetchMarketPrice(collectionId, { includeMagicEden: useMagicEden });
     const allListings = [...meListings, ...satflowListings].sort((a, b) => a.price - b.price);
     const lowestListPrice = allListings.length > 0 ? allListings[0].price : Infinity;
     const floorPriceBtc = lowestListPrice / 100000000;
@@ -371,7 +375,7 @@ class OrdinalsCollectionManager extends BaseCollectionManager {
 
     // Fetch my active listings from both Magic Eden and Satflow
     const walletDetails = deriveWalletDetails(process.env.LOCAL_WALLET_SEED);
-    const myListings = await fetchMyListings(walletDetails.address, collectionId);
+    const myListings = await fetchMyListings(walletDetails.address, collectionId, { includeMagicEden: useMagicEden });
     
     // Create a lookup map that stores all listings per inscription ID
     const listingsMap = new Map();
@@ -407,27 +411,33 @@ class OrdinalsCollectionManager extends BaseCollectionManager {
         // Calculate Satflow Price
         let { price: finalSatflowPrice, isUndercut: isSatflowUndercut } = calculateDynamicPrice(targetListPrice, satflowListings);
 
-        // Calculate Magic Eden Price
-        const { price: mePrice, isUndercut: isMeUndercut } = calculateDynamicPrice(targetListPrice, meListings);
-        let finalMagicEdenPrice = mePrice;
+        let finalMagicEdenPrice = null;
+        let isMeUndercut = false;
+        if (useMagicEden) {
+          // Calculate Magic Eden Price
+          const mePricing = calculateDynamicPrice(targetListPrice, meListings);
+          const mePrice = mePricing.price;
+          isMeUndercut = mePricing.isUndercut;
+          finalMagicEdenPrice = mePrice;
 
-        // Apply ME fee multiplier ONLY if no undercutting occurred
-        if (!isMeUndercut) {
-          finalMagicEdenPrice = Math.ceil(mePrice * MAGIC_EDEN_FEE_MULTIPLIER);
-        }
+          // Apply ME fee multiplier ONLY if no undercutting occurred
+          if (!isMeUndercut) {
+            finalMagicEdenPrice = Math.ceil(mePrice * MAGIC_EDEN_FEE_MULTIPLIER);
+          }
 
-        // --- CROSS-MARKET ADJUSTMENT ---
-        // If the final ME price is lower than the final Satflow price, match it.
-        if (finalMagicEdenPrice < finalSatflowPrice) {
+          // --- CROSS-MARKET ADJUSTMENT ---
+          // If the final ME price is lower than the final Satflow price, match it.
+          if (finalMagicEdenPrice < finalSatflowPrice) {
             console.log(`ℹ Matching ME's aggressive price on Satflow: ${finalMagicEdenPrice} sats (was ${finalSatflowPrice})`);
             finalSatflowPrice = finalMagicEdenPrice;
             isSatflowUndercut = true; // ME undercut is now a Satflow undercut
+          }
         }
 
         // Get all existing listings for this inscription
         const existingListings = listingsMap.get(inscriptionId) || [];
         const satflowListing = existingListings.find(l => l.source === 'satflow');
-        const magicEdenListing = existingListings.find(l => l.source === 'magiceden');
+        const magicEdenListing = useMagicEden ? existingListings.find(l => l.source === 'magiceden') : null;
 
         // Get update threshold for this collection
         const updateThreshold = this.getUpdateThreshold(collectionId);
@@ -448,8 +458,8 @@ class OrdinalsCollectionManager extends BaseCollectionManager {
         }
         
         // Check if we need to list/update on Magic Eden
-        let shouldListMagicEden = true;
-        if (magicEdenListing) {
+        let shouldListMagicEden = useMagicEden;
+        if (useMagicEden && magicEdenListing) {
           const priceDiff = Math.abs(magicEdenListing.price - finalMagicEdenPrice);
           const priceChangePercent = priceDiff / magicEdenListing.price;
           
@@ -469,7 +479,7 @@ class OrdinalsCollectionManager extends BaseCollectionManager {
         }
         
         // List on Magic Eden if needed (independent of Satflow)
-        if (shouldListMagicEden) {
+        if (useMagicEden && shouldListMagicEden) {
           try {
             await listOnMagicEden(item, finalMagicEdenPrice);
             console.log(`✓ Listed ${inscriptionId} on Magic Eden at ${finalMagicEdenPrice} sats`);

--- a/src/services/protocols/ordinals/market.js
+++ b/src/services/protocols/ordinals/market.js
@@ -1,7 +1,14 @@
 const axios = require('axios');
 const { logError } = require('../../../utils/logger');
 const { deriveWalletDetails } = require('../../wallet-utils');
-const { SATFLOW_API_BASE_URL } = require('../../core/environment');
+const { SATFLOW_API_BASE_URL, isMagicEdenEnabled } = require('../../core/environment');
+
+function shouldUseMagicEden(options = {}) {
+  if (typeof options.includeMagicEden === 'boolean') {
+    return options.includeMagicEden;
+  }
+  return isMagicEdenEnabled();
+}
 
 async function fetchSatflowListings(collectionId) {
   const url = `${SATFLOW_API_BASE_URL}/activity/listings?collectionSlug=${collectionId}&sortBy=price&sortDirection=asc&active=true`;
@@ -35,21 +42,38 @@ async function fetchSatflowListings(collectionId) {
   }
 }
 
-async function fetchMyListings(walletAddress, collectionSymbol) {
+async function fetchMagicEdenWalletListings(walletAddress) {
+  const url = `https://api-mainnet.magiceden.us/v2/ord/btc/wallets/tokens?` +
+    `limit=100&offset=0&ownerAddress=${walletAddress}&showAll=true`;
   try {
-    // Fetch from both Magic Eden and Satflow in parallel
+    const { data } = await axios.get(url);
+    return data?.tokens || [];
+  } catch (error) {
+    logError(`Failed to fetch Magic Eden wallet listings: ${error.message}`);
+    return [];
+  }
+}
+
+async function fetchMagicEdenCollectionListings(collectionSymbol) {
+  const url = 'https://api-mainnet.magiceden.us/v2/ord/btc/tokens?' +
+    `offset=0&limit=100&collectionSymbol[]=${collectionSymbol}&sortBy=priceAsc` +
+    '&disablePendingTransactions=true&showAll=true&rbfPreventionListingOnly=false';
+  try {
+    const { data } = await axios.get(url);
+    return data?.tokens || [];
+  } catch (error) {
+    logError(`Failed to fetch Magic Eden market listings: ${error.message}`);
+    return [];
+  }
+}
+
+async function fetchMyListings(walletAddress, collectionSymbol, options = {}) {
+  try {
+    const includeMagicEden = shouldUseMagicEden(options);
+
+    // Fetch Satflow always; Magic Eden only when explicitly enabled.
     const [meData, satflowData] = await Promise.all([
-      (async () => {
-        const url = `https://api-mainnet.magiceden.us/v2/ord/btc/wallets/tokens?` +
-          `limit=100&offset=0&ownerAddress=${walletAddress}&showAll=true`;
-        try {
-          const { data } = await axios.get(url);
-          return data?.tokens || [];
-        } catch (error) {
-          logError(`Failed to fetch Magic Eden listings: ${error.message}`);
-          return [];
-        }
-      })(),
+      includeMagicEden ? fetchMagicEdenWalletListings(walletAddress) : Promise.resolve([]),
       fetchSatflowListings(collectionSymbol)
     ]);
 
@@ -77,7 +101,11 @@ async function fetchMyListings(walletAddress, collectionSymbol) {
     const allListings = [...meListings, ...satflowListings];
 
     console.log(`\n📋 My Active Listings for ${collectionSymbol}:`);
-    console.log(`🔮 Magic Eden: ${meListings.length} listings`);
+    if (includeMagicEden) {
+      console.log(`🔮 Magic Eden: ${meListings.length} listings`);
+    } else {
+      console.log('🔮 Magic Eden: disabled');
+    }
     console.log(`⚡ Satflow: ${satflowListings.length} listings`);
     console.log(`📊 Total: ${allListings.length} listings`);
 
@@ -89,6 +117,10 @@ async function fetchMyListings(walletAddress, collectionSymbol) {
 }
 
 async function fetchCollectionBids(collectionSymbol) {
+  if (!isMagicEdenEnabled()) {
+    return [];
+  }
+
   // Get addresses to filter out from listings
   const walletDetails = deriveWalletDetails(process.env.LOCAL_WALLET_SEED);
   const myAddress = walletDetails.address;
@@ -100,7 +132,7 @@ async function fetchCollectionBids(collectionSymbol) {
   try {
     // 1. Fetch Magic Eden Bids via ZenRows
     if (!process.env.ZENROWS_API_KEY) {
-      logError('ZENROWS_API_KEY is not set. Cannot fetch Magic Eden bids.');
+      console.log('ZENROWS_API_KEY is not set. Skipping Magic Eden bid feed.');
       return [];
     }
     const meBidsUrl = `https://api-mainnet.magiceden.io/v2/ord/btc/collection-offers/collection/${collectionSymbol}?sort=priceDesc&status[]=valid&offset=0`;
@@ -146,7 +178,7 @@ async function fetchCollectionBids(collectionSymbol) {
   }
 }
 
-async function fetchMarketPrice(collectionSymbol) {
+async function fetchMarketPrice(collectionSymbol, options = {}) {
   // Get addresses to filter out from listings
   const walletDetails = deriveWalletDetails(process.env.LOCAL_WALLET_SEED);
   const currentAddress = walletDetails.address;
@@ -156,15 +188,11 @@ async function fetchMarketPrice(collectionSymbol) {
   ]);
 
   try {
-    // Fetch both ME and Satflow listings
+    const includeMagicEden = shouldUseMagicEden(options);
+
+    // Fetch Satflow always; Magic Eden only when explicitly enabled.
     const [meData, satflowData] = await Promise.all([
-      (async () => {
-        const url = 'https://api-mainnet.magiceden.us/v2/ord/btc/tokens?' +
-          `offset=0&limit=100&collectionSymbol[]=${collectionSymbol}&sortBy=priceAsc` +
-          '&disablePendingTransactions=true&showAll=true&rbfPreventionListingOnly=false';
-        const { data } = await axios.get(url);
-        return data?.tokens || [];
-      })(),
+      includeMagicEden ? fetchMagicEdenCollectionListings(collectionSymbol) : Promise.resolve([]),
       fetchSatflowListings(collectionSymbol)
     ]);
 
@@ -189,8 +217,12 @@ async function fetchMarketPrice(collectionSymbol) {
 
     // Debug: Show market data from each source
     console.log(`\n📊 Market Analysis for ${collectionSymbol}:`);
-    console.log(`🔮 Magic Eden: ${meListings.length} listings`);
-    if (meListings.length > 0) {
+    if (includeMagicEden) {
+      console.log(`🔮 Magic Eden: ${meListings.length} listings`);
+    } else {
+      console.log('🔮 Magic Eden: disabled');
+    }
+    if (includeMagicEden && meListings.length > 0) {
       const mePrices = meListings.map(l => l.price).sort((a, b) => a - b);
       console.log(`   └─ Price range: ${mePrices[0].toLocaleString()} - ${mePrices[mePrices.length - 1].toLocaleString()} sats`);
     }
@@ -208,7 +240,7 @@ async function fetchMarketPrice(collectionSymbol) {
     return { meListings, satflowListings };
   } catch (error) {
     logError(`Market price fetch failed: ${error.message}`);
-    return [];
+    return { meListings: [], satflowListings: [] };
   }
 }
 

--- a/src/services/protocols/runes/collection-manager.js
+++ b/src/services/protocols/runes/collection-manager.js
@@ -76,7 +76,17 @@ class RunesCollectionManager extends BaseCollectionManager {
     const maxBidToListRatio = Number(process.env.MAX_BID_TO_LIST_RATIO || process.env.MIN_BID_TO_LIST_RATIO);
     
     // Find lowest list price from market data
-    const lowestListPrice = Math.min(...orders.map(o => o.price));
+    const lowestListPrice = orders.reduce((lowest, order) => {
+      const unitPrice = Number(order.price ?? order.formattedUnitPrice);
+      if (!Number.isFinite(unitPrice) || unitPrice <= 0) {
+        return lowest;
+      }
+      return Math.min(lowest, unitPrice);
+    }, Infinity);
+    if (!Number.isFinite(lowestListPrice)) {
+      console.log(`No valid market prices found for ${envTicker}`);
+      return;
+    }
     const maxAllowedBidPrice = Math.floor(lowestListPrice * maxBidToListRatio);
     
     // Get max bid total for this rune

--- a/src/services/protocols/runes/market.js
+++ b/src/services/protocols/runes/market.js
@@ -1,37 +1,174 @@
 const axios = require('axios');
 const { logError } = require('../../../utils/logger');
+const { SATFLOW_API_BASE_URL, isMagicEdenEnabled } = require('../../core/environment');
 
-/**
- * Fetches valid sell orders for a rune from Magic Eden
- * @param {string} runeTicker - The rune's ticker symbol
- * @returns {Promise<Array>} Array of valid sell orders
- */
-async function fetchRuneOrders(runeTicker) {
+function normalizeRuneTicker(value) {
+  return String(value || '')
+    .replace(/[•.\s_-]/g, '')
+    .toUpperCase();
+}
+
+function getNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : NaN;
+}
+
+function extractTokenAmount(listing, runeMeta) {
+  const divisibility = getNumber(
+    runeMeta?.divisibility ??
+    runeMeta?.decimals ??
+    listing?.collection?.rune_divisibility ??
+    0
+  );
+
+  const formattedMetaAmount = getNumber(runeMeta?.formattedAmount);
+  if (formattedMetaAmount > 0) {
+    return formattedMetaAmount;
+  }
+
+  const rawMetaAmount = getNumber(runeMeta?.amount ?? runeMeta?.rune_amount);
+  if (rawMetaAmount > 0) {
+    if (divisibility > 0 && rawMetaAmount >= Math.pow(10, divisibility)) {
+      return rawMetaAmount / Math.pow(10, divisibility);
+    }
+    return rawMetaAmount;
+  }
+
+  const fallbackAmount = getNumber(
+    listing?.token?.inscription_number ??
+    listing?.ask?.inscriptionNumber ??
+    listing?.inscription_number ??
+    listing?.inscriptionNumber
+  );
+  return fallbackAmount > 0 ? fallbackAmount : NaN;
+}
+
+function toSatflowOrder(listing, targetRuneTicker) {
+  const price = getNumber(listing?.ask?.price ?? listing?.price ?? listing?.listedPrice);
+  if (!(price > 0)) {
+    return null;
+  }
+
+  const target = normalizeRuneTicker(targetRuneTicker);
+  const runeLists = [
+    listing?.ask?.runes_metadata?.runes,
+    listing?.runes_metadata?.runes,
+    listing?.inscription_metadata?.runes,
+    listing?.ask?.inscription_metadata?.runes,
+    listing?.token?.runes
+  ].filter(Array.isArray);
+
+  for (const runes of runeLists) {
+    for (const runeMeta of runes) {
+      const runeName = runeMeta?.name || runeMeta?.ticker || runeMeta?.symbol || runeMeta?.id;
+      if (target && runeName && normalizeRuneTicker(runeName) !== target) {
+        continue;
+      }
+
+      const amount = extractTokenAmount(listing, runeMeta);
+      if (!(amount > 0)) {
+        continue;
+      }
+
+      return {
+        side: 'sell',
+        status: 'valid',
+        isPending: false,
+        formattedAmount: amount.toString(),
+        formattedUnitPrice: (price / amount).toString(),
+        source: 'satflow'
+      };
+    }
+  }
+
+  const fallbackAmount = extractTokenAmount(listing, null);
+  if (fallbackAmount > 0) {
+    return {
+      side: 'sell',
+      status: 'valid',
+      isPending: false,
+      formattedAmount: fallbackAmount.toString(),
+      formattedUnitPrice: (price / fallbackAmount).toString(),
+      source: 'satflow'
+    };
+  }
+
+  return null;
+}
+
+async function fetchSatflowRuneOrders(runeTicker) {
+  if (!process.env.SATFLOW_API_KEY) {
+    logError('SATFLOW_API_KEY is required to fetch rune market data from Satflow');
+    return [];
+  }
+
+  const slugCandidates = [
+    runeTicker,
+    process.env[`${runeTicker}_FULL_TICKER`]
+  ].filter(Boolean);
+
+  const listings = [];
+  for (const collectionSlug of [...new Set(slugCandidates)]) {
+    const url = `${SATFLOW_API_BASE_URL}/activity/listings?collectionSlug=${encodeURIComponent(collectionSlug)}&sortBy=price&sortDirection=asc&active=true`;
+    try {
+      const { data } = await axios.get(url, {
+        headers: {
+          Accept: 'application/json',
+          'x-api-key': process.env.SATFLOW_API_KEY
+        }
+      });
+      listings.push(...(data?.data?.listings || []));
+    } catch (error) {
+      logError(`Satflow rune listing fetch failed for '${collectionSlug}': ${error.message}`);
+    }
+  }
+
+  const targetTicker = process.env[`${runeTicker}_FULL_TICKER`] || runeTicker;
+  const orders = listings
+    .map(listing => toSatflowOrder(listing, targetTicker))
+    .filter(Boolean)
+    .sort((a, b) => Number(a.formattedUnitPrice) - Number(b.formattedUnitPrice));
+
+  return orders;
+}
+
+async function fetchMagicEdenRuneOrders(runeTicker) {
   try {
-    // Get orders sorted by price ascending for optimal market depth calculation
     const url = `https://api-mainnet.magiceden.us/v2/ord/btc/runes/orders/${runeTicker}` +
       '?offset=0&sort=unitPriceAsc&includePending=false&side=sell';
-
     const { data } = await axios.get(url);
-    
-    // Filter for valid sell orders with proper numeric values
+
     return (data?.orders || []).filter(order => {
       if (!order || order.side !== 'sell' || order.status !== 'valid' || order.isPending) {
         return false;
       }
-
-      try {
-        const amount = parseFloat(order.formattedAmount);
-        const unitPrice = parseFloat(order.formattedUnitPrice);
-        return !isNaN(amount) && !isNaN(unitPrice) && amount > 0 && unitPrice > 0;
-      } catch {
-        return false;
-      }
+      const amount = parseFloat(order.formattedAmount);
+      const unitPrice = parseFloat(order.formattedUnitPrice);
+      return !isNaN(amount) && !isNaN(unitPrice) && amount > 0 && unitPrice > 0;
     });
   } catch (error) {
-    logError(`Rune market price fetch failed: ${error.message}`);
+    logError(`Magic Eden rune market fetch failed: ${error.message}`);
     return [];
   }
+}
+
+/**
+ * Fetches valid sell orders for a rune from Satflow.
+ * If Satflow returns no usable orders and ENABLE_MAGIC_EDEN=true, falls back to Magic Eden.
+ * @param {string} runeTicker - The rune's ticker symbol
+ * @returns {Promise<Array>} Array of valid sell orders
+ */
+async function fetchRuneOrders(runeTicker) {
+  const satflowOrders = await fetchSatflowRuneOrders(runeTicker);
+  if (satflowOrders.length > 0) {
+    return satflowOrders;
+  }
+
+  if (!isMagicEdenEnabled()) {
+    return [];
+  }
+
+  return fetchMagicEdenRuneOrders(runeTicker);
 }
 
 /**


### PR DESCRIPTION
This PR removes Magic Eden as a mandatory dependency by introducing ENABLE_MAGIC_EDEN (default false) and making market/listing flows operate in Satflow-first mode. It hardens env validation by requiring SATFLOW_API_KEY in base validation and updates Ordinals logic so ME pricing/listing branches are only used when explicitly enabled. It also replaces Rune market sourcing with Satflow listing-derived orders, keeps optional ME fallback when enabled, and fixes lowest-list-price handling for normalized unit-price orders. README and .env.sample were updated to reflect the new required/optional configuration and behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core market-data sourcing and conditional marketplace listing behavior, which can directly impact bid/list prices and execution if Satflow responses or rune parsing differ from prior Magic Eden feeds.
> 
> **Overview**
> Switches the bot to **Satflow-first mode** by default and gates all Magic Eden market/indexing + listing logic behind `ENABLE_MAGIC_EDEN`.
> 
> Environment validation now requires `SATFLOW_API_KEY`, and Ordinals flows only fetch Magic Eden listings/bid feed and post Magic Eden listings when explicitly enabled (including updated cross-market pricing adjustments).
> 
> Runes market pricing is reworked to derive sell orders from Satflow listings (with new normalization/parsing and `{RUNE_TICKER}_FULL_TICKER` mapping), with an optional Magic Eden fallback only when enabled, plus a fix to lowest-price calculation for unit-price-formatted orders; docs and `.env.sample` are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e8fbf1334c0600fb9b4b04848d646287355e5a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->