### PR TITLE
Remove Magic Eden and switch to Satflow

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -35,7 +35,6 @@ LOCAL_WALLET_SEED_ENCRYPTED="your-encrypted-seed-here"
 SATFLOW_API_KEY="your-satflow-api-key"
 
 # Optional Configuration
-#ZENROWS_API_KEY="your-zenrows-api-key"
 
 # Comma-separated list of additional wallet addresses to ignore when fetching market listings
 # These addresses' listings will be excluded from price calculations (in addition to your own wallet's listings)
@@ -89,7 +88,7 @@ NODEMONKES_BID_BELOW_PERCENT=0.8
 # Format: [RUNE_TICKER]_LIST_ABOVE_PERCENT=[value]
 # Format: [RUNE_TICKER]_MAX_BID_TOTAL=[amount]
 # Format: [RUNE_TICKER]_MARKET_DEPTH_SATS=[amount] (required, e.g. 10000000 for 10M sats depth)
-# Format: [RUNE_TICKER]_FULL_TICKER=[value] (required, maps shortened ticker to full ticker with dots)
+# Format: [RUNE_TICKER]_FULL_TICKER=[value] (required for bid routing and recommended for Satflow market lookups)
 
 # DOGGOTOTHEMOON Rune Settings
 DOGGOTOTHEMOON_LIST_ABOVE_PERCENT=1.2

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 This Node.js application automates bidding and listing for Ordinals/Rune marketplace items. It currently uses:
 
-- Magic Eden (as a price index source)
-- Satflow (for listing items and, later, placing bids)
+- Satflow (for market data, listing items, and placing bids)
 
 The application supports both Ordinals collections and Runes:
 - Ordinals collections (e.g., Runestone, NodeMonkes)
@@ -32,7 +31,6 @@ The application supports both Ordinals collections and Runes:
 | `LOOP_SECONDS` | Interval (in seconds) for each run | 15 |
 | `UPDATE_THRESHOLD` | Minimum price difference (as decimal) required before updating listings/bids | 0.01 (1%) |
 | `IGNORED_MARKET_ADDRESSES` | Comma-separated list of wallet addresses whose listings should be excluded from price calculations | - |
-| `ZENROWS_API_KEY` | API key for ZenRows (used to proxy or scrape data from Magic Eden) | - |
 
 ### Collection-Specific Variables
 
@@ -109,7 +107,7 @@ For enhanced security, especially in production environments, you can encrypt yo
    ```
 
 5. **Signing into Marketplaces**:
-   - Ensure that your wallet address in `.env` matches the address you use on Satflow and Magic Eden
+   - Ensure that your wallet address in `.env` matches the address you use on Satflow
    - This address should hold the Ordinal inscriptions and Runes you intend to list
 
 ## How It Works
@@ -117,8 +115,8 @@ For enhanced security, especially in production environments, you can encrypt yo
 1. **Collection/Rune Configuration**: The bot processes multiple collections and runes specified in the `COLLECTIONS` environment variable.
 
 2. **Fetch Price Data**: 
-   - For Ordinals collections: Calls Magic Eden to get listed items and their sat prices
-   - For Runes: Calls Magic Eden's runes API to get order book data
+   - For Ordinals collections: Calls Satflow to get active listings and their sat prices
+   - For Runes: Calls Satflow to get active rune listings and derive unit prices from them
 
 3. **Calculate Average**: 
    - For Ordinals: Gathers the cheapest N items (default: 10, configurable via `{COLLECTION}_NUM_CHEAPEST_ITEMS`) to compute a baseline average price
@@ -140,12 +138,12 @@ For enhanced security, especially in production environments, you can encrypt yo
 
    **Note for Ordinals**: Due to Satflow API requirements, all Ordinals bid prices are automatically rounded to 1000 sat increments (e.g., 3,000, 4,000, 5,000 sats). This rounding is handled automatically by the bot.
 
-8. **Modularity**: The code supports multiple collections and runes, and is written to extend to multiple marketplaces in the future.
+8. **Modularity**: The code supports multiple collections and runes while keeping market interactions centralized around Satflow.
 
 ## Notes
 
 - Always confirm your transactions on test environment or small amounts first to ensure correctness
-- For advanced features (like multi-collection or multi-marketplace), you can expand the logic in `src/index.js`
+- For advanced collection-specific behavior, you can expand the logic in `src/index.js`
 
 ## Disclaimer
 

--- a/src/services/bip322.js
+++ b/src/services/bip322.js
@@ -73,7 +73,7 @@ function signChallenge(challenge, seed) {
       challenge
     );
     
-    // Return both signature and original challenge for Magic Eden
+    // Return both signature and original challenge for downstream auth flows
     return {
       signature,
       challenge

--- a/src/services/core/environment.js
+++ b/src/services/core/environment.js
@@ -273,8 +273,19 @@ function validateBaseEnvironment() {
   }
 }
 
+function getSatflowConfig(params = {}) {
+  return {
+    params,
+    headers: {
+      Accept: 'application/json',
+      'x-api-key': process.env.SATFLOW_API_KEY
+    }
+  };
+}
+
 module.exports = {
   SATFLOW_API_BASE_URL,
+  getSatflowConfig,
   validateBaseEnvironment,
   validateWalletEnvironment,
   parseBidLadder,

--- a/src/services/core/environment.js
+++ b/src/services/core/environment.js
@@ -4,9 +4,6 @@ const { logError } = require('../../utils/logger');
 // API Base URL - change this single line to test against different endpoints
 const SATFLOW_API_BASE_URL = 'https://api.satflow.com/v1';
 
-// Magic Eden maker fee multiplier (0.5% fee)
-const MAGIC_EDEN_FEE_MULTIPLIER = 1.005;
-
 // Global flag to track if below-floor confirmation has been given
 let belowFloorConfirmationGiven = false;
 
@@ -278,7 +275,6 @@ function validateBaseEnvironment() {
 
 module.exports = {
   SATFLOW_API_BASE_URL,
-  MAGIC_EDEN_FEE_MULTIPLIER,
   validateBaseEnvironment,
   validateWalletEnvironment,
   parseBidLadder,

--- a/src/services/listings.js
+++ b/src/services/listings.js
@@ -1,10 +1,9 @@
 const axios = require('axios');
 const bitcoin = require('bitcoinjs-lib');
 const { deriveWalletDetails, deriveSigningKey, DEFAULT_DERIVATION_PATH } = require('./wallet-utils');
-const { signPSBT, finalizePSBT } = require('./psbt-utils');
-const { signChallenge } = require('./bip322');
+const { signPSBT } = require('./psbt-utils');
 const { logError } = require('../utils/logger');
-const { SATFLOW_API_BASE_URL, MAGIC_EDEN_FEE_MULTIPLIER } = require('./core/environment');
+const { SATFLOW_API_BASE_URL } = require('./core/environment');
 
 async function listOnSatflow(item, listingPriceSats) {
   let intentSellPayload; // Declare outside try block for debug access
@@ -120,145 +119,6 @@ async function listOnSatflow(item, listingPriceSats) {
   }
 }
 
-async function listOnMagicEden(item, listingPriceSats) {
-  let intentPayload; // Declare outside try block for debug access
-  let submitPayload; // Declare outside try block for debug access
-
-  try {
-    const walletDetails = deriveWalletDetails(process.env.LOCAL_WALLET_SEED);
-    const config = {
-      headers: {
-        'x-api-key': process.env.SATFLOW_API_KEY
-      }
-    };
-
-    // Step 1: Create listing intent for Magic Eden
-    intentPayload = {
-      listings: [{
-        price: listingPriceSats,
-        tokenId: item.token.inscription_id
-      }],
-      sellerOrdAddress: walletDetails.address,
-      receiveAddress: walletDetails.address,
-      sellerPublicKey: walletDetails.publicKey,
-      marketplace: 'magiceden'
-    };
-
-    const intentRes = await axios.post(
-      `${SATFLOW_API_BASE_URL}/intent/external-sell`,
-      intentPayload,
-      config
-    );
-
-    const intentData = intentRes.data.data;
-    if (!intentData.success || !intentData.results || intentData.results.length === 0) {
-      throw new Error('No results found in Magic Eden intent response');
-    }
-
-    // Extract data from the first result (we're only listing one item at a time)
-    const result = intentData.results[0];
-
-    const unsignedCombinedPSBTBase64 = result.unsignedCombinedPSBTBase64;
-    const unsignedRBFListingPsbtBase64 = result.listing.seller.unsignedRBFProtectedListingPSBT;
-    const unsignedRBFListingTransientPsbtBase64 = result.listing.seller.unsignedRBFProtectedListingTransientPSBT;
-
-    if (!unsignedCombinedPSBTBase64 || !unsignedRBFListingPsbtBase64) {
-      throw new Error('Missing unsigned PSBTs in Magic Eden intent response');
-    }
-
-    const messageToSign = intentData.messageToSign;
-    const sessionId = intentData.sessionId ?? Math.round(Math.random() * 9999).toString();
-
-    if (!messageToSign) {
-      // DEBUG: More detailed error logging (REMOVE AFTER DEBUGGING)
-      console.log('DEBUG - Missing fields! intentData:', JSON.stringify(intentData, null, 2));
-      throw new Error('Missing messageToSign in Magic Eden intent response');
-    }
-
-    // Step 2: Sign PSBTs
-    const derivationPath = process.env.CUSTOM_DERIVATION_PATH || DEFAULT_DERIVATION_PATH;
-    const signingKey = deriveSigningKey(
-      process.env.LOCAL_WALLET_SEED,
-      derivationPath
-    );
-
-    // Sign the combined PSBT (secure, all inputs)
-    let combinedPsbt = bitcoin.Psbt.fromBase64(unsignedCombinedPSBTBase64, { network: bitcoin.networks.bitcoin });
-    combinedPsbt = signPSBT(combinedPsbt, signingKey, false, [0], walletDetails.tapKey);
-    const signedCombinedPSBT = combinedPsbt.toBase64();
-
-    // Sign the listing PSBT (secure, typically input 0)
-    let listingPsbt = bitcoin.Psbt.fromBase64(unsignedRBFListingPsbtBase64, { network: bitcoin.networks.bitcoin });
-    listingPsbt = signPSBT(listingPsbt, signingKey, true, [0], walletDetails.tapKey);
-    const signedListingPSBT = listingPsbt.toBase64();
-
-    // Sign the listing PSBT (secure, typically input 0)
-    let listingTransientPsbt = bitcoin.Psbt.fromBase64(unsignedRBFListingTransientPsbtBase64, { network: bitcoin.networks.bitcoin });
-    listingTransientPsbt = signPSBT(listingTransientPsbt, signingKey, true, [0], walletDetails.tapKey);
-    const signedListingTransientPSBT = listingTransientPsbt.toBase64();
-
-    // Step 3: Sign BIP322 message
-    const { signature: signedMessage, challenge: unsignedMessage } = signChallenge(
-      messageToSign,
-      process.env.LOCAL_WALLET_SEED
-    );
-
-    // Step 4: Submit signed listing to Magic Eden
-    submitPayload = {
-      listings: [{
-        ...result,
-        inscriptionId: item.token.inscription_id,
-        price: listingPriceSats,
-        sellerReceiveAddress: walletDetails.address,
-        signedRBFProtectedListingPSBT: signedListingPSBT,
-        signedRBFProtectedListingTransientPSBT: signedListingTransientPSBT
-      }],
-      signedCombinedPSBT: signedCombinedPSBT,
-      sellerPublicKey: walletDetails.publicKey,
-      sellerOrdAddress: walletDetails.address,
-      receiveAddress: walletDetails.address,
-      type: 'ordinals',
-      marketplace: 'magiceden',
-      signedMessage: signedMessage,
-      unsignedMessage: unsignedMessage,
-      sessionId: sessionId
-    };
-
-    const submitRes = await axios.post(
-      `${SATFLOW_API_BASE_URL}/list/external`,
-      submitPayload,
-      config
-    );
-
-    if (submitRes.status !== 200) {
-      throw new Error(`Unexpected response: ${submitRes.status}`);
-    }
-
-    return submitRes.data;
-  } catch (error) {
-    logError(`Failed to list ${item.token.inscription_id} on Magic Eden: ${error.message}`);
-    console.log(error.stack);
-
-    // Debug logging for 400 and 500 errors
-    if (error.response && (error.response.status === 400 || error.response.status === 500)) {
-      const errorType = error.response.status === 400 ? '400 Bad Request' : '500 Internal Server Error';
-      logError(`DEBUG - Magic Eden ${errorType} Details:`);
-      logError('Response status:', error.response.status);
-      logError('Response data:', JSON.stringify(error.response.data, null, 2));
-      if (intentPayload) {
-        logError('Intent payload sent:', JSON.stringify(intentPayload, null, 2));
-      }
-      if (submitPayload) {
-        logError('Submit payload sent:', JSON.stringify(submitPayload, null, 2));
-      }
-      logError('Request headers:', JSON.stringify(error.config?.headers, null, 2));
-    }
-
-    throw error;
-  }
-}
-
 module.exports = {
-  listOnSatflow,
-  listOnMagicEden
+  listOnSatflow
 };

--- a/src/services/protocols/ordinals/collection-manager.js
+++ b/src/services/protocols/ordinals/collection-manager.js
@@ -2,8 +2,8 @@ const { BaseCollectionManager } = require('../../core/collection-manager');
 const { OrdinalsBiddingService } = require('./bidding');
 const { fetchMarketPrice, fetchMyListings, fetchCollectionBids } = require('./market');
 const { calculateTargetPrice, calculateDynamicPrice, calculateDynamicBidPrice } = require('./pricing');
-const { listOnSatflow, listOnMagicEden } = require('../../listings');
-const { parseBidLadder, MAGIC_EDEN_FEE_MULTIPLIER } = require('../../core/environment');
+const { listOnSatflow } = require('../../listings');
+const { parseBidLadder } = require('../../core/environment');
 const { logError } = require('../../../utils/logger');
 const { deriveWalletDetails } = require('../../wallet-utils');
 
@@ -64,12 +64,11 @@ class OrdinalsCollectionManager extends BaseCollectionManager {
     }
 
     // Fetch market data and calculate prices
-    const { meListings, satflowListings } = await fetchMarketPrice(collectionId);
-    const allListings = [...meListings, ...satflowListings].sort((a, b) => a.price - b.price);
-    const lowestListPrice = allListings.length > 0 ? allListings[0].price : Infinity;
+    const { listings: marketListings } = await fetchMarketPrice(collectionId);
+    const lowestListPrice = marketListings.length > 0 ? marketListings[0].price : Infinity;
     const floorPriceBtc = lowestListPrice / 100000000;
 
-    const averagePrice = calculateTargetPrice(allListings, collectionId);
+    const averagePrice = calculateTargetPrice(marketListings, collectionId);
 
     if (averagePrice <= 0) {
       console.log(`No valid market data for ${collectionId}`);
@@ -369,7 +368,7 @@ class OrdinalsCollectionManager extends BaseCollectionManager {
       }
     }
 
-    // Fetch my active listings from both Magic Eden and Satflow
+    // Fetch my active listings from Satflow
     const walletDetails = deriveWalletDetails(process.env.LOCAL_WALLET_SEED);
     const myListings = await fetchMyListings(walletDetails.address, collectionId);
     
@@ -403,31 +402,11 @@ class OrdinalsCollectionManager extends BaseCollectionManager {
           console.log(`ℹ Premium price for ${inscriptionId}: ${targetListPrice} sats (${premiumMultiplier}x average)`);
         }
 
-        // --- PLATFORM-SPECIFIC PRICING ---
-        // Calculate Satflow Price
-        let { price: finalSatflowPrice, isUndercut: isSatflowUndercut } = calculateDynamicPrice(targetListPrice, satflowListings);
-
-        // Calculate Magic Eden Price
-        const { price: mePrice, isUndercut: isMeUndercut } = calculateDynamicPrice(targetListPrice, meListings);
-        let finalMagicEdenPrice = mePrice;
-
-        // Apply ME fee multiplier ONLY if no undercutting occurred
-        if (!isMeUndercut) {
-          finalMagicEdenPrice = Math.ceil(mePrice * MAGIC_EDEN_FEE_MULTIPLIER);
-        }
-
-        // --- CROSS-MARKET ADJUSTMENT ---
-        // If the final ME price is lower than the final Satflow price, match it.
-        if (finalMagicEdenPrice < finalSatflowPrice) {
-            console.log(`ℹ Matching ME's aggressive price on Satflow: ${finalMagicEdenPrice} sats (was ${finalSatflowPrice})`);
-            finalSatflowPrice = finalMagicEdenPrice;
-            isSatflowUndercut = true; // ME undercut is now a Satflow undercut
-        }
+        const { price: finalListingPrice, isUndercut } = calculateDynamicPrice(targetListPrice, marketListings);
 
         // Get all existing listings for this inscription
         const existingListings = listingsMap.get(inscriptionId) || [];
         const satflowListing = existingListings.find(l => l.source === 'satflow');
-        const magicEdenListing = existingListings.find(l => l.source === 'magiceden');
 
         // Get update threshold for this collection
         const updateThreshold = this.getUpdateThreshold(collectionId);
@@ -435,47 +414,22 @@ class OrdinalsCollectionManager extends BaseCollectionManager {
         // Check if we need to list/update on Satflow
         let shouldListSatflow = true;
         if (satflowListing) {
-          const priceDiff = Math.abs(satflowListing.price - finalSatflowPrice);
+          const priceDiff = Math.abs(satflowListing.price - finalListingPrice);
           const priceChangePercent = priceDiff / satflowListing.price;
           
-          if (!isSatflowUndercut && priceChangePercent <= updateThreshold) {
-            console.log(`ℹ Skipping Satflow for ${inscriptionId}: Listed at ${satflowListing.price} sats (within ${updateThreshold * 100}% threshold of ${finalSatflowPrice})`);
+          if (!isUndercut && priceChangePercent <= updateThreshold) {
+            console.log(`ℹ Skipping Satflow for ${inscriptionId}: Listed at ${satflowListing.price} sats (within ${updateThreshold * 100}% threshold of ${finalListingPrice})`);
             shouldListSatflow = false;
           } else {
             console.log(`ℹ Updating Satflow for ${inscriptionId}: Price change ${(priceChangePercent * 100).toFixed(2)}% exceeds threshold`);
-            console.log(`  Current: ${satflowListing.price} sats → Target: ${finalSatflowPrice} sats`);
-          }
-        }
-        
-        // Check if we need to list/update on Magic Eden
-        let shouldListMagicEden = true;
-        if (magicEdenListing) {
-          const priceDiff = Math.abs(magicEdenListing.price - finalMagicEdenPrice);
-          const priceChangePercent = priceDiff / magicEdenListing.price;
-          
-          if (!isMeUndercut && priceChangePercent <= updateThreshold) {
-            console.log(`ℹ Skipping Magic Eden for ${inscriptionId}: Listed at ${magicEdenListing.price} sats (within ${updateThreshold * 100}% threshold of ${finalMagicEdenPrice})`);
-            shouldListMagicEden = false;
-          } else {
-            console.log(`ℹ Updating Magic Eden for ${inscriptionId}: Price change ${(priceChangePercent * 100).toFixed(2)}% exceeds threshold`);
-            console.log(`  Current: ${magicEdenListing.price} sats → Target: ${finalMagicEdenPrice} sats`);
+            console.log(`  Current: ${satflowListing.price} sats → Target: ${finalListingPrice} sats`);
           }
         }
 
         // List on Satflow if needed
         if (shouldListSatflow) {
-          await listOnSatflow(item, finalSatflowPrice);
-          console.log(`✓ Listed ${inscriptionId} on Satflow at ${finalSatflowPrice} sats`);
-        }
-        
-        // List on Magic Eden if needed (independent of Satflow)
-        if (shouldListMagicEden) {
-          try {
-            await listOnMagicEden(item, finalMagicEdenPrice);
-            console.log(`✓ Listed ${inscriptionId} on Magic Eden at ${finalMagicEdenPrice} sats`);
-          } catch (magicEdenError) {
-            logError(`Magic Eden listing failed for ${inscriptionId}: ${magicEdenError.message}`);
-          }
+          await listOnSatflow(item, finalListingPrice);
+          console.log(`✓ Listed ${inscriptionId} on Satflow at ${finalListingPrice} sats`);
         }
       } catch (error) {
         logError(`✗ Failed ${item.token.inscription_id}: ${error.message}`);

--- a/src/services/protocols/ordinals/market.js
+++ b/src/services/protocols/ordinals/market.js
@@ -24,13 +24,19 @@ function normalizeSatflowListing(item) {
 }
 
 function normalizeSatflowBid(item) {
+  const bid = item?.bid;
   const price = Number(
     item?.price ??
-    item?.bid?.price ??
+    bid?.price ??
     item?.bidPrice ??
     item?.amount
   );
-  const maker = item?.bidderAddress || item?.bidderTokenReceiveAddress || item?.maker || item?.bidder?.address;
+  const maker = bid?.bidderAddress ||
+    bid?.bidderTokenReceiveAddress ||
+    item?.bidderAddress ||
+    item?.bidderTokenReceiveAddress ||
+    item?.maker ||
+    item?.bidder?.address;
 
   if (!maker || !Number.isFinite(price) || price <= 0) {
     return null;

--- a/src/services/protocols/ordinals/market.js
+++ b/src/services/protocols/ordinals/market.js
@@ -65,6 +65,12 @@ function normalizeSatflowBid(item) {
     .map(address => address.trim());
   const uniqueBidderAddresses = [...new Set(bidderAddresses)];
   const attribute = bid?.attribute ?? item?.attribute;
+  const inscriptionId = bid?.inscriptionId ??
+    bid?.inscription_id ??
+    item?.inscriptionId ??
+    item?.inscription_id ??
+    item?.token?.inscription_id ??
+    item?.token?.id;
 
   if (!Number.isFinite(price) || price <= 0) {
     return null;
@@ -75,7 +81,8 @@ function normalizeSatflowBid(item) {
     price,
     maker: uniqueBidderAddresses[0],
     bidderAddresses: uniqueBidderAddresses,
-    attribute
+    attribute,
+    inscriptionId
   };
 }
 
@@ -168,7 +175,9 @@ async function fetchCollectionBids(collectionSymbol) {
           return false;
         }
 
-        return !bid.attribute && !bid.bidderAddresses.some(address => ignoredAddresses.has(address));
+        return !bid.attribute &&
+          !bid.inscriptionId &&
+          !bid.bidderAddresses.some(address => ignoredAddresses.has(address));
       })
       .sort((a, b) => b.price - a.price);
 

--- a/src/services/protocols/ordinals/market.js
+++ b/src/services/protocols/ordinals/market.js
@@ -5,13 +5,35 @@ const { SATFLOW_API_BASE_URL, getSatflowConfig } = require('../../core/environme
 
 const loggedSatflowBidFeedErrors = new Set();
 
+function getActivityItems(data, ...legacyKeys) {
+  const activityData = data?.data;
+
+  if (Array.isArray(activityData?.items)) {
+    return activityData.items;
+  }
+
+  for (const key of legacyKeys) {
+    if (Array.isArray(activityData?.[key])) {
+      return activityData[key];
+    }
+  }
+
+  return [];
+}
+
 function normalizeSatflowListing(item) {
   const ask = item?.ask;
-  const price = Number(ask?.price);
-  const inscriptionId = ask?.inscriptionId || item?.token?.inscription_id || item?.token?.id;
-  const seller = ask?.sellerOrdAddress || item?.seller || item?.owner;
+  const listing = item?.listing;
+  const price = Number(ask?.price ?? item?.price ?? listing?.price);
+  const inscriptionId = ask?.inscriptionId || item?.inscriptionId || item?.token?.inscription_id || item?.token?.id;
+  const seller = ask?.sellerOrdAddress ||
+    item?.sellerOrdAddress ||
+    listing?.sellerAddress ||
+    item?.sellerAddress ||
+    item?.seller ||
+    item?.owner;
 
-  if (!inscriptionId || !seller || !Number.isFinite(price) || price <= 0) {
+  if (!inscriptionId || !Number.isFinite(price) || price <= 0) {
     return null;
   }
 
@@ -38,7 +60,7 @@ function normalizeSatflowBid(item) {
     item?.maker ||
     item?.bidder?.address;
 
-  if (!maker || !Number.isFinite(price) || price <= 0) {
+  if (!Number.isFinite(price) || price <= 0) {
     return null;
   }
 
@@ -63,7 +85,7 @@ async function fetchSatflowListings(collectionId) {
       getSatflowConfig(params)
     );
 
-    return data.data?.listings || [];
+    return getActivityItems(data, 'listings');
   } catch (error) {
     logError(`❌ Satflow API Error for collection '${collectionId}':`);
     logError(`   📍 Params: ${JSON.stringify(params)}`);
@@ -96,7 +118,7 @@ async function fetchSatflowBids(collectionId) {
       })
     );
 
-    return data.data?.bids || data.data?.results || [];
+    return getActivityItems(data, 'bids', 'results');
   } catch (error) {
     if (!loggedSatflowBidFeedErrors.has(collectionId)) {
       loggedSatflowBidFeedErrors.add(collectionId);
@@ -133,7 +155,7 @@ async function fetchCollectionBids(collectionSymbol) {
   try {
     const satflowBids = (await fetchSatflowBids(collectionSymbol))
       .map(normalizeSatflowBid)
-      .filter(bid => bid && !ignoredAddresses.has(bid.maker))
+      .filter(bid => bid && (!bid.maker || !ignoredAddresses.has(bid.maker)))
       .sort((a, b) => b.price - a.price);
 
     console.log(`\n📊 Collection Bid Analysis for ${collectionSymbol}:`);
@@ -163,7 +185,7 @@ async function fetchMarketPrice(collectionSymbol) {
   try {
     const listings = (await fetchSatflowListings(collectionSymbol))
       .map(normalizeSatflowListing)
-      .filter(listing => listing && !ignoredAddresses.has(listing.seller));
+      .filter(listing => listing && (!listing.seller || !ignoredAddresses.has(listing.seller)));
 
     console.log(`\n📊 Market Analysis for ${collectionSymbol}:`);
     console.log(`⚡ Satflow: ${listings.length} listings`);

--- a/src/services/protocols/ordinals/market.js
+++ b/src/services/protocols/ordinals/market.js
@@ -64,6 +64,7 @@ function normalizeSatflowBid(item) {
     .filter(address => typeof address === 'string' && address.trim())
     .map(address => address.trim());
   const uniqueBidderAddresses = [...new Set(bidderAddresses)];
+  const attribute = bid?.attribute ?? item?.attribute;
 
   if (!Number.isFinite(price) || price <= 0) {
     return null;
@@ -73,7 +74,8 @@ function normalizeSatflowBid(item) {
     source: 'satflow',
     price,
     maker: uniqueBidderAddresses[0],
-    bidderAddresses: uniqueBidderAddresses
+    bidderAddresses: uniqueBidderAddresses,
+    attribute
   };
 }
 
@@ -166,7 +168,7 @@ async function fetchCollectionBids(collectionSymbol) {
           return false;
         }
 
-        return !bid.bidderAddresses.some(address => ignoredAddresses.has(address));
+        return !bid.attribute && !bid.bidderAddresses.some(address => ignoredAddresses.has(address));
       })
       .sort((a, b) => b.price - a.price);
 

--- a/src/services/protocols/ordinals/market.js
+++ b/src/services/protocols/ordinals/market.js
@@ -1,19 +1,9 @@
 const axios = require('axios');
 const { logError } = require('../../../utils/logger');
 const { deriveWalletDetails } = require('../../wallet-utils');
-const { SATFLOW_API_BASE_URL } = require('../../core/environment');
+const { SATFLOW_API_BASE_URL, getSatflowConfig } = require('../../core/environment');
 
-let hasLoggedSatflowBidFeedUnavailable = false;
-
-function getSatflowConfig(params = {}) {
-  return {
-    params,
-    headers: {
-      Accept: 'application/json',
-      'x-api-key': process.env.SATFLOW_API_KEY
-    }
-  };
-}
+const loggedSatflowBidFeedErrors = new Set();
 
 function normalizeSatflowListing(item) {
   const ask = item?.ask;
@@ -102,8 +92,8 @@ async function fetchSatflowBids(collectionId) {
 
     return data.data?.bids || data.data?.results || [];
   } catch (error) {
-    if (!hasLoggedSatflowBidFeedUnavailable) {
-      hasLoggedSatflowBidFeedUnavailable = true;
+    if (!loggedSatflowBidFeedErrors.has(collectionId)) {
+      loggedSatflowBidFeedErrors.add(collectionId);
       logError(`Satflow bid feed unavailable for '${collectionId}': ${error.message}`);
     }
     return [];

--- a/src/services/protocols/ordinals/market.js
+++ b/src/services/protocols/ordinals/market.js
@@ -53,12 +53,17 @@ function normalizeSatflowBid(item) {
     item?.bidPrice ??
     item?.amount
   );
-  const maker = bid?.bidderAddress ||
-    bid?.bidderTokenReceiveAddress ||
-    item?.bidderAddress ||
-    item?.bidderTokenReceiveAddress ||
-    item?.maker ||
-    item?.bidder?.address;
+  const bidderAddresses = [
+    bid?.bidderAddress,
+    bid?.bidderTokenReceiveAddress,
+    item?.bidderAddress,
+    item?.bidderTokenReceiveAddress,
+    item?.maker,
+    item?.bidder?.address
+  ]
+    .filter(address => typeof address === 'string' && address.trim())
+    .map(address => address.trim());
+  const uniqueBidderAddresses = [...new Set(bidderAddresses)];
 
   if (!Number.isFinite(price) || price <= 0) {
     return null;
@@ -67,7 +72,8 @@ function normalizeSatflowBid(item) {
   return {
     source: 'satflow',
     price,
-    maker
+    maker: uniqueBidderAddresses[0],
+    bidderAddresses: uniqueBidderAddresses
   };
 }
 
@@ -155,7 +161,13 @@ async function fetchCollectionBids(collectionSymbol) {
   try {
     const satflowBids = (await fetchSatflowBids(collectionSymbol))
       .map(normalizeSatflowBid)
-      .filter(bid => bid && (!bid.maker || !ignoredAddresses.has(bid.maker)))
+      .filter(bid => {
+        if (!bid) {
+          return false;
+        }
+
+        return !bid.bidderAddresses.some(address => ignoredAddresses.has(address));
+      })
       .sort((a, b) => b.price - a.price);
 
     console.log(`\n📊 Collection Bid Analysis for ${collectionSymbol}:`);

--- a/src/services/protocols/ordinals/market.js
+++ b/src/services/protocols/ordinals/market.js
@@ -3,83 +3,121 @@ const { logError } = require('../../../utils/logger');
 const { deriveWalletDetails } = require('../../wallet-utils');
 const { SATFLOW_API_BASE_URL } = require('../../core/environment');
 
+let hasLoggedSatflowBidFeedUnavailable = false;
+
+function getSatflowConfig(params = {}) {
+  return {
+    params,
+    headers: {
+      Accept: 'application/json',
+      'x-api-key': process.env.SATFLOW_API_KEY
+    }
+  };
+}
+
+function normalizeSatflowListing(item) {
+  const ask = item?.ask;
+  const price = Number(ask?.price);
+  const inscriptionId = ask?.inscriptionId || item?.token?.inscription_id || item?.token?.id;
+  const seller = ask?.sellerOrdAddress || item?.seller || item?.owner;
+
+  if (!inscriptionId || !seller || !Number.isFinite(price) || price <= 0) {
+    return null;
+  }
+
+  return {
+    source: 'satflow',
+    inscriptionId,
+    price,
+    seller
+  };
+}
+
+function normalizeSatflowBid(item) {
+  const price = Number(
+    item?.price ??
+    item?.bid?.price ??
+    item?.bidPrice ??
+    item?.amount
+  );
+  const maker = item?.bidderAddress || item?.bidderTokenReceiveAddress || item?.maker || item?.bidder?.address;
+
+  if (!maker || !Number.isFinite(price) || price <= 0) {
+    return null;
+  }
+
+  return {
+    source: 'satflow',
+    price,
+    maker
+  };
+}
+
 async function fetchSatflowListings(collectionId) {
-  const url = `${SATFLOW_API_BASE_URL}/activity/listings?collectionSlug=${collectionId}&sortBy=price&sortDirection=asc&active=true`;
+  const params = {
+    collectionSlug: collectionId,
+    sortBy: 'price',
+    sortDirection: 'asc',
+    active: true
+  };
+
   try {
-    const { data } = await axios.get(url, {
-      headers: {
-        'Accept': 'application/json',
-        'x-api-key': process.env.SATFLOW_API_KEY
-      }
-    });
+    const { data } = await axios.get(
+      `${SATFLOW_API_BASE_URL}/activity/listings`,
+      getSatflowConfig(params)
+    );
 
     return data.data?.listings || [];
   } catch (error) {
     logError(`❌ Satflow API Error for collection '${collectionId}':`);
-    logError(`   📍 URL: ${url}`);
+    logError(`   📍 Params: ${JSON.stringify(params)}`);
     logError(`   📊 Status: ${error.response?.status || 'No status'}`);
     logError(`   📄 Response Data:`, JSON.stringify(error.response?.data, null, 2));
     logError(`   🔑 API Key Present: ${process.env.SATFLOW_API_KEY ? 'Yes' : 'No'}`);
     logError(`   🔑 Request Headers:`, JSON.stringify(error.config?.headers, null, 2));
     logError(`   💬 Full Error Message: ${error.message}`);
-    
-    // Additional context for debugging
+
     if (error.response?.status === 404) {
       logError(`   ❓ 404 Troubleshooting:`);
       logError(`      • Check if collection_id '${collectionId}' exists in Satflow`);
       logError(`      • Verify endpoint URL is correct`);
       logError(`      • Confirm API version (v1) is supported`);
     }
-    
+
+    return [];
+  }
+}
+
+async function fetchSatflowBids(collectionId) {
+  try {
+    const { data } = await axios.get(
+      `${SATFLOW_API_BASE_URL}/activity/bids`,
+      getSatflowConfig({
+        collectionSlug: collectionId,
+        sortBy: 'price',
+        sortDirection: 'desc',
+        active: true
+      })
+    );
+
+    return data.data?.bids || data.data?.results || [];
+  } catch (error) {
+    if (!hasLoggedSatflowBidFeedUnavailable) {
+      hasLoggedSatflowBidFeedUnavailable = true;
+      logError(`Satflow bid feed unavailable for '${collectionId}': ${error.message}`);
+    }
     return [];
   }
 }
 
 async function fetchMyListings(walletAddress, collectionSymbol) {
   try {
-    // Fetch from both Magic Eden and Satflow in parallel
-    const [meData, satflowData] = await Promise.all([
-      (async () => {
-        const url = `https://api-mainnet.magiceden.us/v2/ord/btc/wallets/tokens?` +
-          `limit=100&offset=0&ownerAddress=${walletAddress}&showAll=true`;
-        try {
-          const { data } = await axios.get(url);
-          return data?.tokens || [];
-        } catch (error) {
-          logError(`Failed to fetch Magic Eden listings: ${error.message}`);
-          return [];
-        }
-      })(),
-      fetchSatflowListings(collectionSymbol)
-    ]);
-
-    // Filter Magic Eden results for the specific collection and listed items
-    const meListings = meData
-      .filter(item => item.collectionSymbol === collectionSymbol && item.listed)
-      .map(item => ({
-        source: 'magiceden',
-        inscriptionId: item.id,
-        price: item.listedPrice,
-        seller: item.owner
-      }));
-
-    // Filter Satflow results for the wallet address
-    const satflowListings = satflowData
-      .filter(item => item.ask && item.ask.sellerOrdAddress === walletAddress)
-      .map(item => ({
-        source: 'satflow',
-        inscriptionId: item.ask.inscriptionId,
-        price: item.ask.price,
-        seller: item.ask.sellerOrdAddress
-      }));
-
-    // Merge both sources
-    const allListings = [...meListings, ...satflowListings];
+    const allListings = (await fetchSatflowListings(collectionSymbol))
+      .map(normalizeSatflowListing)
+      .filter(listing => listing && listing.seller === walletAddress);
 
     console.log(`\n📋 My Active Listings for ${collectionSymbol}:`);
-    console.log(`🔮 Magic Eden: ${meListings.length} listings`);
-    console.log(`⚡ Satflow: ${satflowListings.length} listings`);
-    console.log(`📊 Total: ${allListings.length} listings`);
+    console.log(`⚡ Satflow: ${allListings.length} listings`);
 
     return allListings;
   } catch (error) {
@@ -89,7 +127,6 @@ async function fetchMyListings(walletAddress, collectionSymbol) {
 }
 
 async function fetchCollectionBids(collectionSymbol) {
-  // Get addresses to filter out from listings
   const walletDetails = deriveWalletDetails(process.env.LOCAL_WALLET_SEED);
   const myAddress = walletDetails.address;
   const ignoredAddresses = new Set([
@@ -98,45 +135,18 @@ async function fetchCollectionBids(collectionSymbol) {
   ]);
 
   try {
-    // 1. Fetch Magic Eden Bids via ZenRows
-    if (!process.env.ZENROWS_API_KEY) {
-      logError('ZENROWS_API_KEY is not set. Cannot fetch Magic Eden bids.');
-      return [];
-    }
-    const meBidsUrl = `https://api-mainnet.magiceden.io/v2/ord/btc/collection-offers/collection/${collectionSymbol}?sort=priceDesc&status[]=valid&offset=0`;
-    const zenrowsUrl = `https://api.zenrows.com/v1/?apikey=${process.env.ZENROWS_API_KEY}&url=${encodeURIComponent(meBidsUrl)}`;
-    
-    const { data: meData } = await axios.get(zenrowsUrl);
-    
-    const meBids = (meData.offers || [])
-      // Filter out our own bids
-      .filter(offer => !ignoredAddresses.has(offer.maker))
-      .map(offer => {
-        // Adjust for ME's 2% taker fee to get the effective price to beat
-        const adjustedPrice = Math.ceil(offer.price.amount * 0.98);
-        return {
-          source: 'magiceden',
-          price: adjustedPrice,
-          maker: offer.maker,
-        };
-      });
-
-    // 2. Fetch Satflow Bids (Placeholder for future implementation)
-    // const satflowBids = []; 
-
-    // Combine and sort all bids
-    const allBids = [...meBids /*, ...satflowBids*/]
-      .sort((a, b) => b.price - a.price); // Sort descending
+    const satflowBids = (await fetchSatflowBids(collectionSymbol))
+      .map(normalizeSatflowBid)
+      .filter(bid => bid && !ignoredAddresses.has(bid.maker))
+      .sort((a, b) => b.price - a.price);
 
     console.log(`\n📊 Collection Bid Analysis for ${collectionSymbol}:`);
-    console.log(`🔮 Magic Eden: ${meBids.length} active bids`);
-    if (meBids.length > 0) {
-      console.log(`   └─ Highest ME bid (effective price): ${meBids[0].price.toLocaleString()} sats`);
+    console.log(`⚡ Satflow: ${satflowBids.length} active bids`);
+    if (satflowBids.length > 0) {
+      console.log(`   └─ Highest Satflow bid: ${satflowBids[0].price.toLocaleString()} sats`);
     }
-    // console.log(`⚡ Satflow: ${satflowBids.length} active bids`);
 
-    return allBids;
-
+    return satflowBids;
   } catch (error) {
     logError(`Collection bid fetch failed for ${collectionSymbol}: ${error.message}`);
     if (error.response) {
@@ -147,7 +157,6 @@ async function fetchCollectionBids(collectionSymbol) {
 }
 
 async function fetchMarketPrice(collectionSymbol) {
-  // Get addresses to filter out from listings
   const walletDetails = deriveWalletDetails(process.env.LOCAL_WALLET_SEED);
   const currentAddress = walletDetails.address;
   const ignoredAddresses = new Set([
@@ -156,59 +165,23 @@ async function fetchMarketPrice(collectionSymbol) {
   ]);
 
   try {
-    // Fetch both ME and Satflow listings
-    const [meData, satflowData] = await Promise.all([
-      (async () => {
-        const url = 'https://api-mainnet.magiceden.us/v2/ord/btc/tokens?' +
-          `offset=0&limit=100&collectionSymbol[]=${collectionSymbol}&sortBy=priceAsc` +
-          '&disablePendingTransactions=true&showAll=true&rbfPreventionListingOnly=false';
-        const { data } = await axios.get(url);
-        return data?.tokens || [];
-      })(),
-      fetchSatflowListings(collectionSymbol)
-    ]);
+    const listings = (await fetchSatflowListings(collectionSymbol))
+      .map(normalizeSatflowListing)
+      .filter(listing => listing && !ignoredAddresses.has(listing.seller));
 
-    // Filter out ignored listings and normalize data structure
-    const meListings = meData
-      .filter(item => !ignoredAddresses.has(item.owner))
-      .map(item => ({
-        source: 'magiceden',
-        inscriptionId: item.id,
-        price: item.listedPrice,
-        seller: item.owner
-      }));
-
-    const satflowListings = satflowData
-      .filter(item => item.ask && !ignoredAddresses.has(item.ask.sellerOrdAddress))
-      .map(item => ({
-        source: 'satflow',
-        inscriptionId: item.ask.inscriptionId,
-        price: item.ask.price,
-        seller: item.ask.sellerOrdAddress
-      }));
-
-    // Debug: Show market data from each source
     console.log(`\n📊 Market Analysis for ${collectionSymbol}:`);
-    console.log(`🔮 Magic Eden: ${meListings.length} listings`);
-    if (meListings.length > 0) {
-      const mePrices = meListings.map(l => l.price).sort((a, b) => a - b);
-      console.log(`   └─ Price range: ${mePrices[0].toLocaleString()} - ${mePrices[mePrices.length - 1].toLocaleString()} sats`);
-    }
-    
-    console.log(`⚡ Satflow: ${satflowListings.length} listings`);
-    if (satflowListings.length > 0) {
-      const satflowPrices = satflowListings.map(l => l.price).sort((a, b) => a - b);
-      console.log(`   └─ Price range: ${satflowPrices[0].toLocaleString()} - ${satflowPrices[satflowPrices.length - 1].toLocaleString()} sats`);
+    console.log(`⚡ Satflow: ${listings.length} listings`);
+    if (listings.length > 0) {
+      const prices = listings.map(listing => listing.price).sort((a, b) => a - b);
+      console.log(`   └─ Price range: ${prices[0].toLocaleString()} - ${prices[prices.length - 1].toLocaleString()} sats`);
     }
 
-    // Sort each list by price independently
-    meListings.sort((a, b) => a.price - b.price);
-    satflowListings.sort((a, b) => a.price - b.price);
+    listings.sort((a, b) => a.price - b.price);
 
-    return { meListings, satflowListings };
+    return { listings };
   } catch (error) {
     logError(`Market price fetch failed: ${error.message}`);
-    return [];
+    return { listings: [] };
   }
 }
 

--- a/src/services/protocols/runes/collection-manager.js
+++ b/src/services/protocols/runes/collection-manager.js
@@ -55,7 +55,7 @@ class RunesCollectionManager extends BaseCollectionManager {
     console.log(`\n=== Processing Rune ${envTicker} ===`);
     
     // Fetch market data and calculate prices
-    const orders = await fetchRuneOrders(apiTicker);
+    const orders = await fetchRuneOrders(apiTicker, depthSats);
     if (!orders || orders.length === 0) {
       console.log(`No orders found for ${envTicker}`);
       return;

--- a/src/services/protocols/runes/collection-manager.js
+++ b/src/services/protocols/runes/collection-manager.js
@@ -28,8 +28,8 @@ class RunesCollectionManager extends BaseCollectionManager {
     // Remove any 'rune:' prefix if present
     const envTicker = runeTicker.replace(/^rune:/i, '');
     
-    // Keep ticker in original case for API
-    const apiTicker = envTicker;
+    // Satflow uses the full rune ticker as the collection slug when available.
+    const apiTicker = process.env[`${envTicker}_FULL_TICKER`] || envTicker;
     
     // Use uppercase for env var names
     const depthKey = `${envTicker}_MARKET_DEPTH_SATS`;

--- a/src/services/protocols/runes/market.js
+++ b/src/services/protocols/runes/market.js
@@ -35,11 +35,24 @@ function bigIntToDecimal(value, divisibility) {
   return `${whole.toString()}.${fraction.toString().padStart(divisibility, '0').replace(/0+$/, '')}`;
 }
 
+function firstRune(value) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function getRuneData(listing) {
+  return (
+    firstRune(listing?.runes) ??
+    firstRune(listing?.ask?.runesData?.runes) ??
+    firstRune(listing?.rune) ??
+    firstRune(listing?.ask?.runes) ??
+    firstRune(listing?.runesData?.runes)
+  );
+}
+
 function getRuneDivisibility(listing) {
+  const runeData = getRuneData(listing);
   const divisibility = Number(
-    listing?.rune?.divisibility ??
-    listing?.runes?.[0]?.divisibility ??
-    listing?.ask?.runes?.[0]?.divisibility ??
+    runeData?.divisibility ??
     listing?.collection?.rune_divisibility ??
     listing?.token?.rune_divisibility ??
     0
@@ -49,6 +62,7 @@ function getRuneDivisibility(listing) {
 }
 
 function normalizeRuneOrder(listing) {
+  const runeData = getRuneData(listing);
   const totalPrice = Number(listing?.ask?.price ?? listing?.price);
   const explicitUnitPrice = Number(
     listing?.unitPrice ??
@@ -58,9 +72,7 @@ function normalizeRuneOrder(listing) {
   );
   const divisibility = getRuneDivisibility(listing);
   const rawAmount = toBigInt(
-    listing?.rune?.amount ??
-    listing?.runes?.[0]?.amount ??
-    listing?.ask?.runes?.[0]?.amount ??
+    runeData?.amount ??
     listing?.token?.rune_amount ??
     listing?.token?.runeAmount
   );
@@ -112,7 +124,7 @@ async function fetchRuneOrders(runeTicker) {
       `${SATFLOW_API_BASE_URL}/activity/listings`,
       getSatflowConfig({
         collectionSlug: runeTicker,
-        sortBy: 'price',
+        sortBy: 'unitPrice',
         sortDirection: 'asc',
         active: true
       })

--- a/src/services/protocols/runes/market.js
+++ b/src/services/protocols/runes/market.js
@@ -7,6 +7,22 @@ const { logError } = require('../../../utils/logger');
  * @param {string} runeTicker - The rune collection slug used by Satflow
  * @returns {Promise<Array>} Array of normalized sell orders
  */
+function getActivityItems(data, ...legacyKeys) {
+  const activityData = data?.data;
+
+  if (Array.isArray(activityData?.items)) {
+    return activityData.items;
+  }
+
+  for (const key of legacyKeys) {
+    if (Array.isArray(activityData?.[key])) {
+      return activityData[key];
+    }
+  }
+
+  return [];
+}
+
 function toBigInt(value) {
   if (typeof value === 'bigint') {
     return value;
@@ -82,7 +98,11 @@ function normalizeRuneOrder(listing) {
     amountString = bigIntToDecimal(rawAmount, divisibility);
   } else {
     const displayAmount = Number(
+      listing?.formattedAmount ??
+      listing?.amount ??
+      listing?.runeAmount ??
       listing?.token?.amount ??
+      listing?.token?.rune_amount_formatted ??
       listing?.quantity ??
       listing?.token?.inscription_number ??
       listing?.token?.inscriptionNumber
@@ -130,7 +150,7 @@ async function fetchRuneOrders(runeTicker) {
       })
     );
 
-    return (data?.data?.listings || [])
+    return getActivityItems(data, 'listings')
       .map(normalizeRuneOrder)
       .filter(order => order !== null);
   } catch (error) {

--- a/src/services/protocols/runes/market.js
+++ b/src/services/protocols/runes/market.js
@@ -2,9 +2,12 @@ const axios = require('axios');
 const { SATFLOW_API_BASE_URL, getSatflowConfig } = require('../../core/environment');
 const { logError } = require('../../../utils/logger');
 
+const RUNE_ORDER_PAGE_SIZE = 100;
+
 /**
  * Fetches valid sell orders for a rune from Satflow.
  * @param {string} runeTicker - The rune collection slug used by Satflow
+ * @param {number} depthSats - Market depth in satoshis to cover before stopping
  * @returns {Promise<Array>} Array of normalized sell orders
  */
 function getActivityItems(data, ...legacyKeys) {
@@ -138,21 +141,58 @@ function normalizeRuneOrder(listing) {
   };
 }
 
-async function fetchRuneOrders(runeTicker) {
-  try {
-    const { data } = await axios.get(
-      `${SATFLOW_API_BASE_URL}/activity/listings`,
-      getSatflowConfig({
-        collectionSlug: runeTicker,
-        sortBy: 'unitPrice',
-        sortDirection: 'asc',
-        active: true
-      })
-    );
+function calculateOrderValue(order) {
+  const amount = Number(order.formattedAmount);
+  const unitPrice = Number(order.formattedUnitPrice);
+  const value = amount * unitPrice;
 
-    return getActivityItems(data, 'listings')
-      .map(normalizeRuneOrder)
-      .filter(order => order !== null);
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+async function fetchRuneOrders(runeTicker, depthSats) {
+  const orders = [];
+  const shouldFetchToDepth = Number.isFinite(depthSats) && depthSats > 0;
+  let accumulatedValue = 0;
+  let page = 1;
+  let totalPages = Infinity;
+
+  try {
+    while (page <= totalPages) {
+      const { data } = await axios.get(
+        `${SATFLOW_API_BASE_URL}/activity/listings`,
+        getSatflowConfig({
+          collectionSlug: runeTicker,
+          sortBy: 'unitPrice',
+          sortDirection: 'asc',
+          active: true,
+          page,
+          pageSize: RUNE_ORDER_PAGE_SIZE
+        })
+      );
+
+      const items = getActivityItems(data, 'listings');
+      const normalizedOrders = items
+        .map(normalizeRuneOrder)
+        .filter(order => order !== null);
+
+      orders.push(...normalizedOrders);
+      accumulatedValue += normalizedOrders.reduce((sum, order) => sum + calculateOrderValue(order), 0);
+
+      const responseTotalPages = Number(data?.data?.pagination?.totalPages);
+      if (Number.isFinite(responseTotalPages) && responseTotalPages > 0) {
+        totalPages = responseTotalPages;
+      } else if (items.length < RUNE_ORDER_PAGE_SIZE) {
+        break;
+      }
+
+      if (!shouldFetchToDepth || accumulatedValue >= depthSats || items.length === 0) {
+        break;
+      }
+
+      page += 1;
+    }
+
+    return orders;
   } catch (error) {
     logError(`Rune market price fetch failed: ${error.message}`);
     return [];

--- a/src/services/protocols/runes/market.js
+++ b/src/services/protocols/runes/market.js
@@ -1,33 +1,136 @@
 const axios = require('axios');
+const { SATFLOW_API_BASE_URL } = require('../../core/environment');
 const { logError } = require('../../../utils/logger');
 
 /**
- * Fetches valid sell orders for a rune from Magic Eden
- * @param {string} runeTicker - The rune's ticker symbol
- * @returns {Promise<Array>} Array of valid sell orders
+ * Fetches valid sell orders for a rune from Satflow.
+ * @param {string} runeTicker - The rune collection slug used by Satflow
+ * @returns {Promise<Array>} Array of normalized sell orders
  */
+function getSatflowConfig(params = {}) {
+  return {
+    params,
+    headers: {
+      Accept: 'application/json',
+      'x-api-key': process.env.SATFLOW_API_KEY
+    }
+  };
+}
+
+function toBigInt(value) {
+  if (typeof value === 'bigint') {
+    return value;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return BigInt(Math.trunc(value));
+  }
+
+  if (typeof value === 'string' && /^-?\d+$/.test(value.trim())) {
+    return BigInt(value.trim());
+  }
+
+  return null;
+}
+
+function bigIntToDecimal(value, divisibility) {
+  const divisor = BigInt(10) ** BigInt(divisibility);
+  const whole = value / divisor;
+  const fraction = value % divisor;
+
+  if (fraction === 0n) {
+    return whole.toString();
+  }
+
+  return `${whole.toString()}.${fraction.toString().padStart(divisibility, '0').replace(/0+$/, '')}`;
+}
+
+function getRuneDivisibility(listing) {
+  const divisibility = Number(
+    listing?.rune?.divisibility ??
+    listing?.runes?.[0]?.divisibility ??
+    listing?.ask?.runes?.[0]?.divisibility ??
+    listing?.collection?.rune_divisibility ??
+    listing?.token?.rune_divisibility ??
+    0
+  );
+
+  return Number.isFinite(divisibility) && divisibility >= 0 ? divisibility : 0;
+}
+
+function normalizeRuneOrder(listing) {
+  const totalPrice = Number(listing?.ask?.price ?? listing?.price);
+  const explicitUnitPrice = Number(
+    listing?.unitPrice ??
+    listing?.ask?.unitPrice ??
+    listing?.pricePerUnit ??
+    listing?.ask?.pricePerUnit
+  );
+  const divisibility = getRuneDivisibility(listing);
+  const rawAmount = toBigInt(
+    listing?.rune?.amount ??
+    listing?.runes?.[0]?.amount ??
+    listing?.ask?.runes?.[0]?.amount ??
+    listing?.token?.rune_amount ??
+    listing?.token?.runeAmount
+  );
+
+  let amountString;
+  if (rawAmount !== null) {
+    amountString = bigIntToDecimal(rawAmount, divisibility);
+  } else {
+    const displayAmount = Number(
+      listing?.token?.inscription_number ??
+      listing?.token?.inscriptionNumber ??
+      listing?.token?.amount ??
+      listing?.quantity
+    );
+
+    if (!Number.isFinite(displayAmount) || displayAmount <= 0) {
+      return null;
+    }
+
+    amountString = displayAmount.toString();
+  }
+
+  const amount = Number(amountString);
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return null;
+  }
+
+  const unitPrice = Number.isFinite(explicitUnitPrice) && explicitUnitPrice > 0
+    ? explicitUnitPrice
+    : totalPrice / amount;
+
+  if (!Number.isFinite(unitPrice) || unitPrice <= 0) {
+    return null;
+  }
+
+  return {
+    side: 'sell',
+    status: 'valid',
+    isPending: false,
+    price: unitPrice,
+    formattedAmount: amountString,
+    formattedUnitPrice: unitPrice.toString()
+  };
+}
+
 async function fetchRuneOrders(runeTicker) {
   try {
-    // Get orders sorted by price ascending for optimal market depth calculation
-    const url = `https://api-mainnet.magiceden.us/v2/ord/btc/runes/orders/${runeTicker}` +
-      '?offset=0&sort=unitPriceAsc&includePending=false&side=sell';
+    const { data } = await axios.get(
+      `${SATFLOW_API_BASE_URL}/activity/listings`,
+      getSatflowConfig({
+        collectionSlug: runeTicker,
+        sortBy: 'price',
+        sortDirection: 'asc',
+        active: true
+      })
+    );
 
-    const { data } = await axios.get(url);
-    
-    // Filter for valid sell orders with proper numeric values
-    return (data?.orders || []).filter(order => {
-      if (!order || order.side !== 'sell' || order.status !== 'valid' || order.isPending) {
-        return false;
-      }
-
-      try {
-        const amount = parseFloat(order.formattedAmount);
-        const unitPrice = parseFloat(order.formattedUnitPrice);
-        return !isNaN(amount) && !isNaN(unitPrice) && amount > 0 && unitPrice > 0;
-      } catch {
-        return false;
-      }
-    });
+    return (data?.data?.listings || [])
+      .map(normalizeRuneOrder)
+      .filter(order => order !== null);
   } catch (error) {
     logError(`Rune market price fetch failed: ${error.message}`);
     return [];

--- a/src/services/protocols/runes/market.js
+++ b/src/services/protocols/runes/market.js
@@ -1,5 +1,5 @@
 const axios = require('axios');
-const { SATFLOW_API_BASE_URL } = require('../../core/environment');
+const { SATFLOW_API_BASE_URL, getSatflowConfig } = require('../../core/environment');
 const { logError } = require('../../../utils/logger');
 
 /**
@@ -7,16 +7,6 @@ const { logError } = require('../../../utils/logger');
  * @param {string} runeTicker - The rune collection slug used by Satflow
  * @returns {Promise<Array>} Array of normalized sell orders
  */
-function getSatflowConfig(params = {}) {
-  return {
-    params,
-    headers: {
-      Accept: 'application/json',
-      'x-api-key': process.env.SATFLOW_API_KEY
-    }
-  };
-}
-
 function toBigInt(value) {
   if (typeof value === 'bigint') {
     return value;
@@ -80,10 +70,10 @@ function normalizeRuneOrder(listing) {
     amountString = bigIntToDecimal(rawAmount, divisibility);
   } else {
     const displayAmount = Number(
-      listing?.token?.inscription_number ??
-      listing?.token?.inscriptionNumber ??
       listing?.token?.amount ??
-      listing?.quantity
+      listing?.quantity ??
+      listing?.token?.inscription_number ??
+      listing?.token?.inscriptionNumber
     );
 
     if (!Number.isFinite(displayAmount) || displayAmount <= 0) {

--- a/src/services/wallet-utils.js
+++ b/src/services/wallet-utils.js
@@ -38,7 +38,7 @@ function deriveWalletDetails(seed) {
   // Get tap key (full public key in hex)
   const tapKey = Buffer.from(child.publicKey).toString('hex');
   
-  // Get public key in hex format (for Magic Eden)
+  // Get public key in hex format for downstream signing flows
   const publicKey = Buffer.from(child.publicKey).toString('hex');
   
   return {


### PR DESCRIPTION
Removes all Magic Eden and ZenRows references from the bot and docs. Routes Ordinals market discovery, active listings, and repricing through Satflow only, and rewrites Rune price discovery to derive unit prices from Satflow listings while using {RUNE}_FULL_TICKER for Satflow slugs. Deletes the external Magic Eden listing path and fee multiplier, and degrades Ordinals external bid discovery to a Satflow-only feed with a safe empty fallback if that feed is unavailable. Updates the README and .env sample to match the Satflow-only configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it rewires core market data, bidding discovery, and listing repricing to Satflow-only endpoints, including new normalization/pagination logic that could impact price calculations and order sizing if Satflow responses differ.
> 
> **Overview**
> **Removes all Magic Eden/ZenRows integration and makes Satflow the sole marketplace dependency.** Docs and `.env.sample` are updated accordingly (dropping `ZENROWS_API_KEY`, clarifying `{RUNE}_FULL_TICKER` usage, and documenting Satflow-only pricing/bidding/listing flows).
> 
> Ordinals market discovery, active listing detection, and dynamic repricing now use only Satflow listings, eliminating cross-market price merging, Magic Eden fee adjustments, and the `listOnMagicEden` external listing path. Bid discovery for Ordinals is switched to Satflow’s bid activity feed with normalization/filtering and a safe empty fallback when the feed is unavailable.
> 
> Runes price discovery is rewritten to derive unit prices from Satflow rune listings (with pagination and depth-based early stopping), and rune collection slugs can be routed via `{RUNE}_FULL_TICKER` to match Satflow’s expected identifiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9a4077d498d2d31a09346d98757aac2f68ea2b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->